### PR TITLE
Added ability to define a different SSL port for the redirects

### DIFF
--- a/test/ring/middleware/ssl_test.clj
+++ b/test/ring/middleware/ssl_test.clj
@@ -42,7 +42,18 @@
     (testing "HTTPS request"
       (let [response (handler (request :get "https://localhost/"))]
         (is (= (:status response) 200))
-        (is (nil? (get-header response "location")))))))
+        (is (nil? (get-header response "location"))))))
+
+  (let [handler (wrap-ssl-redirect (constantly (response "")) {:ssl-port 8443})]
+    (testing "HTTP GET request with different SSL port"
+      (let [response (handler (request :get "/"))]
+        (is (= (:status response) 301))
+        (is (= (get-header response "location") "https://localhost:8443/"))))
+
+    (testing "HTTP POST request with different SSL port"
+      (let [response (handler (request :post "/"))]
+        (is (= (:status response) 307))
+        (is (= (get-header response "location") "https://localhost:8443/"))))))
 
 (deftest test-wrap-hsts
   (testing "defaults"


### PR DESCRIPTION
This patch allows to specify another HTTPS/SSL port than 443 (for example, 8443 during development) by adding a options-map with the key `:ssl-port` to the `wrap-ssl-redirect` function.

`request-url` is an adapted version of the one in `ring.util.request`, which also takes the port into account.

Please feel free to refactor the code to your liking.
