### PR TITLE
Add :exempt-paths option to wrap-ssl-redirect

### DIFF
--- a/src/ring/middleware/ssl.clj
+++ b/src/ring/middleware/ssl.clj
@@ -37,11 +37,13 @@
 
   Accepts the following options:
 
-  :ssl-port - the SSL port to use for redirects, defaults to 443."
+  :ssl-port     - the SSL port to use for redirects, defaults to 443.
+  :exempt-paths - A list of paths that should not be redirected."
   {:arglists '([handler] [handler options])}
-  [handler & [{:keys [ssl-port]}]]
+  [handler & [{:keys [ssl-port exempt-paths]}]]
   (fn [request]
-    (if (= (:scheme request) :https)
+    (if (or (= (:scheme request) :https)
+            (and exempt-paths (contains? (set exempt-paths) (:uri request))))
       (handler request)
       (-> (resp/redirect (https-url (req/request-url request) ssl-port))
           (resp/status   (if (get-request? request) 301 307))))))

--- a/test/ring/middleware/ssl_test.clj
+++ b/test/ring/middleware/ssl_test.clj
@@ -53,7 +53,18 @@
     (testing "HTTP POST request with custom SSL port"
       (let [response (handler (request :post "/"))]
         (is (= (:status response) 307))
-        (is (= (get-header response "location") "https://localhost:8443/"))))))
+        (is (= (get-header response "location") "https://localhost:8443/")))))
+
+  (let [handler (wrap-ssl-redirect (constantly (response "")) {:exempt-paths ["/healthcheck"]})]
+    (testing "HTTP request"
+      (let [response (handler (request :get "/healthcheck"))]
+        (is (= (:status response) 200))
+        (is (nil? (get-header response "location")))))
+
+    (testing "HTTPS request"
+      (let [response (handler (request :get "/healthcheck"))]
+        (is (= (:status response) 200))
+        (is (nil? (get-header response "location")))))))
 
 (deftest test-wrap-hsts
   (testing "defaults"


### PR DESCRIPTION
It's useful to be able to exempt some specific paths from the SSL redirect. An example where this feature is useful: AWS instances in an ELB need a path that give a 200 response status to consider the instance healthy, a 301/307 is not acceptable and will cause the instance to stay out of service.

@weavejester Hope this change makes sense, let me know if there's anything you'd like me to tweak.