### PR TITLE
Make forwarded scheme handle comma separated schemes

### DIFF
--- a/src/ring/middleware/ssl.clj
+++ b/src/ring/middleware/ssl.clj
@@ -20,7 +20,9 @@
      (fn [req]
        (let [header  (str/lower-case header)
              default (name (:scheme req))
-             scheme  (str/lower-case (get-in req [:headers header] default))]
+             scheme  (-> (get-in req [:headers header] default)
+                         (str/split #",")
+                         last str/trim str/lower-case)]
          (assert (or (= scheme "http") (= scheme "https")))
          (handler (assoc req :scheme (keyword scheme)))))))
 

--- a/test/ring/middleware/ssl_test.clj
+++ b/test/ring/middleware/ssl_test.clj
@@ -19,7 +19,12 @@
           (is (= (:body response) "https")))
         (let [response (handler (-> (request :get "https://localhost/")
                                     (header "x-forwarded-proto" "http")))]
-          (is (= (:body response) "http")))))
+          (is (= (:body response) "http"))))
+
+      (testing "comma separated header"
+        (let [response (handler (-> (request :get "/")
+                                    (header "x-forwarded-proto" "http, https")))]
+          (is (= (:body response) "https")))))
 
     (testing "custom header"
       (let [handler  (wrap-forwarded-scheme handler "X-Foo")


### PR DESCRIPTION
When using HAProxy to add `X-Forwarded-Proto` via `reqadd X-Forwarded-Proto ...` and the header already exists, the value will be comma separated. This causes an assertion error to be thrown.

The real issue is with the HAProxy configuration as it should detect the presence of the header and behave accordingly. I'm not sure if this should be a concern of ring-ssl. Thoughts?
