### PR TITLE
Add support for WebSocket schemes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring/ring-ssl "0.2.2-SNAPSHOT"
+(defproject ring/ring-ssl "0.2.1"
   :description "Ring middleware for managing HTTPS requests"
   :url "https://github.com/ring-clojure/ring-ssl"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring/ring-ssl "0.2.1"
+(defproject ring/ring-ssl "0.2.2-SNAPSHOT"
   :description "Ring middleware for managing HTTPS requests"
   :url "https://github.com/ring-clojure/ring-ssl"
   :license {:name "The MIT License"

--- a/test/ring/middleware/ssl_test.clj
+++ b/test/ring/middleware/ssl_test.clj
@@ -33,7 +33,17 @@
       (let [response (handler (request :get "/"))]
         (is (= (:status response) 301))
         (is (= (get-header response "location") "https://localhost/"))))
-    
+
+    (testing "HTTP GET request (with query params)"
+      (let [response (handler (request :get "/" {:foo "bar"}))]
+        (is (= (:status response) 301))
+        (is (= (get-header response "location") "https://localhost/?foo=bar"))))
+
+    (testing "HTTP GET request (non-standard port)"
+      (let [response (handler (request :get "http://localhost:8080/"))]
+        (is (= (:status response) 301))
+        (is (= (get-header response "location") "https://localhost/"))))
+
     (testing "HTTP POST request"
       (let [response (handler (request :post "/"))]
         (is (= (:status response) 307))
@@ -42,11 +52,31 @@
     (testing "HTTPS request"
       (let [response (handler (request :get "https://localhost/"))]
         (is (= (:status response) 200))
+        (is (nil? (get-header response "location")))))
+
+    (testing "HTTPS request (non-standard port)"
+      (let [response (handler (request :get "https://localhost:8443/"))]
+        (is (= (:status response) 200))
+        (is (nil? (get-header response "location")))))
+
+    (testing "WS request"
+      (let [response (handler (request :get "ws://localhost/"))]
+        (is (= (:status response) 301))
+        (is (= (get-header response "location") "wss://localhost/"))))
+
+    (testing "WSS request"
+      (let [response (handler (request :get "wss://localhost/"))]
+        (is (= (:status response) 200))
         (is (nil? (get-header response "location"))))))
 
   (let [handler (wrap-ssl-redirect (constantly (response "")) {:ssl-port 8443})]
     (testing "HTTP GET request with custom SSL port"
       (let [response (handler (request :get "/"))]
+        (is (= (:status response) 301))
+        (is (= (get-header response "location") "https://localhost:8443/"))))
+
+    (testing "HTTP GET request (non-standard port) with custom SSL port"
+      (let [response (handler (request :get "http://localhost:8080/"))]
         (is (= (:status response) 301))
         (is (= (get-header response "location") "https://localhost:8443/"))))
 


### PR DESCRIPTION
Supports redirects from `ws://` scheme to `wss://`. To do that, I had to change the way the secure URL is generated, since the java.net.URL throws a `java.net.MalformedURLException` on instantiation with the ws scheme. 

PR submitted for feedback at this point. Unit tests pass, but I'm still testing this with my app. I'll comment when I'm satisfied with that.