### PR TITLE
If a handler returns nil, do not add headers

### DIFF
--- a/src/ring/middleware/ssl.clj
+++ b/src/ring/middleware/ssl.clj
@@ -69,5 +69,5 @@
   {:arglists '([handler] [handler options])}
   [handler & [{:as options}]]
   (fn [request]
-    (-> (handler request)
-        (resp/header "Strict-Transport-Security" (build-hsts-header options)))))
+    (when-let [res (handler request)]
+       (resp/header res "Strict-Transport-Security" (build-hsts-header options)))))

--- a/test/ring/middleware/ssl_test.clj
+++ b/test/ring/middleware/ssl_test.clj
@@ -56,9 +56,14 @@
         (is (= (get-header response "location") "https://localhost:8443/"))))))
 
 (deftest test-wrap-hsts
+  (testing "no matching handler"
+    (let [handler  (wrap-hsts (constantly nil))
+          response (handler (request :get "/not-found"))]
+      (is (nil? response))))
+
   (testing "defaults"
     (let [handler  (wrap-hsts (constantly (response "")))
-          response (handler (request :get "/"))]
+          response (handler (request :get "/not-found"))]
       (is (= (get-header response "strict-transport-security")
              "max-age=31536000; includeSubDomains"))))
   


### PR DESCRIPTION
Handlers that return nil indicate that they cannot handle the given
request. A common use case is to handle 404s:

```clojure
(def handler
  (-> (routes (GET "/hello.txt" [] ...) ...)
    ...
    (wrap-hsts)
    (not-found "That page is missing")))

;; not-found does not return a 404
(handler {:url "/missing-page" ...})
;; -> {:headers {"strict-transport-security" "max-age=..."}}
```

Anyone using this middleware in like this will not have 404 pages.